### PR TITLE
Regular expression removed from precompile items

### DIFF
--- a/lib/ionicons-rails.rb
+++ b/lib/ionicons-rails.rb
@@ -2,7 +2,7 @@ module Ionicons
   module Rails
     class Engine < ::Rails::Engine
       initializer "ionicons-rails.assets.precompile" do |app|
-        app.config.assets.precompile << %r(ionicons\.(?:eot|svg|ttf|woff)$)
+        app.config.assets.precompile += %w(ionicons*.eot ionicons*.svg ionicons*.ttf ionicons*.woff)
       end
     end
   end


### PR DESCRIPTION
As you may know sprocket does not support regular expression object anymore.
